### PR TITLE
updated 'minimal DaVinci DecayTreeTuple job' link

### DIFF
--- a/14-rerun-stripping.md
+++ b/14-rerun-stripping.md
@@ -19,7 +19,7 @@ the decisions of the stripping that ran during the central MC production are pla
 To solve this issue, we need to run an instance of `EventNodeKiller` to remove the decisions from the MC production so that our custom stripping can write there instead.
 This is nice, because most tools expect to read the stripping decisions from the default location, so we won't have to reconfigure anything.
 
-[This example](code/14-rerun-stripping/options.py) is an extended version of the [minimal DaVinci DecayTreeTuple job](09-minimal-dv-job.html) that additionally runs the corresponding stripping line from Stripping 21.
+[This example](code/14-rerun-stripping/options.py) is an extended version of the [minimal DaVinci DecayTreeTuple job](code/09-minimal-dv/ntuple_options.py) that additionally runs the corresponding stripping line from Stripping 21.
 
 Take a look at the file and try to find out what has changed compared to the [minimal DaVinci example](code/09-minimal-dv/ntuple_options.py).
 


### PR DESCRIPTION
Changed the broken link for 'minimal DaVinci DecayTreeTuple job' (line 22) to match the working link for 'minimal DaVinci example' (line 24)